### PR TITLE
add preflight response

### DIFF
--- a/SimpleVoiceroid2Proxy/HttpRequest.cs
+++ b/SimpleVoiceroid2Proxy/HttpRequest.cs
@@ -74,6 +74,14 @@ namespace SimpleVoiceroid2Proxy
                     text = json?.text;
                     break;
                 }
+                case "OPTIONS":
+                {
+                    response.AddHeader("Access-Control-Allow-Method", "GET, POST, OPTIONS");
+                    response.AddHeader("Access-Control-Allow-Headers", "Content-Type");
+                    response.AddHeader("Access-Control-Max-Age", "7200");
+                    response.StatusCode = (int) HttpStatusCode.NoContent;
+                    return;
+                }
             }
 
             if (string.IsNullOrWhiteSpace(text))


### PR DESCRIPTION
CORS error occurred when POST request from browser.
the cause of this problem is not responding to preflight request,
so  added response as a countermeasure.